### PR TITLE
replace scoped

### DIFF
--- a/lib/geokit-acts-as-mappable/acts_as_mappable.rb
+++ b/lib/geokit-acts-as-mappable/acts_as_mappable.rb
@@ -106,7 +106,7 @@ module Geokit
       end
 
       def geo_scope(options = {})
-        arel = self.is_a?(ActiveRecord::Relation) ? self : self.scoped
+        arel = self.is_a?(ActiveRecord::Relation) ? self : self.where(nil)
 
         origin  = extract_origin_from_options(options)
         units   = extract_units_from_options(options)


### PR DESCRIPTION
@bellycard/platform 

As part of my bite-service upgrade this line was causing a failure while running spec: https://github.com/bellycard/bite-service/blob/master/app/models/bite.rb#L56

This is because scoped is deprecated in the updated version of active record - changing this locally made the test pass.

@ywong19, thanks for helping me dig into this. 

Fix discussed here: https://github.com/rails/rails/issues/12756
